### PR TITLE
Convert README to example project content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# :construction: WIP :construction: Zilker Jekyll Theme
+# Example Project
 
-Zilker is a work-in-progress Jekyll theme designed for City websites hosted on GitHub Pages.
+<!-- Edit this file to fit your project after cloning or forking the theme repo. -->
 
-## Features
+This is an example README for new projects using the Zilker Theme. To set up a new site using Zilker, first follow the instructions at https://cityofaustin.github.io/zilker-theme/, then edit this file in your project's repository.
 
-TBD
+## Contributing
 
-## Usage
+To learn about how this site is set up, and how to edit it, read the [GitHub Pages guide].
 
-GitHub Pages doesn't currently support custom [gem themes], so we recommend forking this repository to use the theme for new GitHub Pages sites.
+[GitHub Pages guide]: http://guides.austintexas.io/github-pages/
 
-Updates will be tagged and released using [semantic versioning] to indicate compatibility changes that may affect downstream forks.
+## Theme
 
-[gem themes]: https://jekyllrb.com/docs/themes/
-[semantic versioning]: https://semver.org
+<!-- Keep this section if you think you might want to update the theme in the future. -->
 
-## Configuration
+This site is based on the [Zilker Theme]. In most cases, it probably started as a clone of the theme's repository, which means that you can update the theme files using `git merge`:
 
-TBD
+```
+$ git checkout -b theme-update
+$ git remote add zilker https://github.com/cityofaustin/zilker-theme.git
+$ git fetch zilker
+$ git merge zilker/master
+```
 
-## Components
+Note: merging theme updates in this way is only likely to succeed if the theme files haven't changed in this project. If they have, you may need to resolve merge conflicts to proceed, which requires an intermediate understanding of Git.
 
-TBD
-
-## Layouts
-
-TBD
+[Zilker Theme]: https://github.com/cityofaustin/zilker-theme


### PR DESCRIPTION
This converts the master branch README to one more appropriate for
new projects based on Zilker, mainly to reduce the likelihood that
merging theme updates in downstream repos would result in merge
conflicts.

The gh-pages branch README, and the version published at
https://cityofaustin.github.io/zilker-theme/, will act as the primary
README for the theme project itself, including instructions on how to
create new sites based on Zilker.